### PR TITLE
Update `axios` due security issue (https://www.npmjs.com/advisories/880)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "should": "^11.2.0"
   },
   "dependencies": {
-    "axios": "^0.15.3",
+    "axios": "^0.19.0",
     "query-string": "^4.3.2",
     "sha1": "^1.1.1",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Versions of `axios` prior to 0.18.1 are vulnerable to Denial of Service. If a request exceeds the maxContentLength property, the package prints an error but does not stop the request. This may cause high CPU usage and lead to Denial of Service. More details: 